### PR TITLE
refactor(test): Improve ProtocolVersions.t.sol coverage and quality

### DIFF
--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -33,7 +33,6 @@ contract ProtocolVersions_Version_Test is ProtocolVersions_TestInit {
     }
 }
 
-
 /// @title ProtocolVersions_Initialize_Test
 /// @notice Test contract for ProtocolVersions `initialize` function.
 contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
@@ -103,7 +102,6 @@ contract ProtocolVersions_SetRequired_Test is ProtocolVersions_TestInit {
         protocolVersions.setRequired(ProtocolVersion.wrap(_ver));
     }
 
-
     /// @notice Tests that `setRequired` reverts if the caller is not the owner.
     function test_setRequired_notOwner_reverts() external {
         vm.expectRevert("Ownable: caller is not the owner");
@@ -135,7 +133,6 @@ contract ProtocolVersions_SetRecommended_Test is ProtocolVersions_TestInit {
     /// @notice Tests that `setRecommended` reverts if the caller is not the owner.
     function test_setRecommended_notOwner_reverts() external {
         vm.expectRevert("Ownable: caller is not the owner");
-        
         protocolVersions.setRecommended(ProtocolVersion.wrap(0));
     }
 }

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -24,6 +24,16 @@ contract ProtocolVersions_TestInit is CommonTest {
     }
 }
 
+/// @title ProtocolVersions_Version_Test
+/// @notice Test contract for ProtocolVersions `version` function.
+contract ProtocolVersions_Version_Test is ProtocolVersions_TestInit {
+    /// @notice Ensures the semantic version string is non-empty.
+    function test_version_nonEmpty_succeeds() external view {
+        assert(bytes(protocolVersions.version()).length > 0);
+    }
+}
+
+
 /// @title ProtocolVersions_Initialize_Test
 /// @notice Test contract for ProtocolVersions `initialize` function.
 contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
@@ -53,9 +63,9 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
 
         // The order depends here
         vm.expectEmit(true, true, true, true, address(protocolVersions));
-        emit ConfigUpdate(0, IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(required));
+        emit ConfigUpdate(protocolVersions.VERSION(), IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(required));
         vm.expectEmit(true, true, true, true, address(protocolVersions));
-        emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(recommended));
+        emit ConfigUpdate(protocolVersions.VERSION(), IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(recommended));
 
         vm.prank(EIP1967Helper.getAdmin(address(protocolVersions)));
         IProxy(payable(address(protocolVersions))).upgradeToAndCall(
@@ -78,12 +88,21 @@ contract ProtocolVersions_SetRequired_Test is ProtocolVersions_TestInit {
     /// @notice Tests that `setRequired` updates the required protocol version successfully.
     function testFuzz_setRequired_succeeds(uint256 _version) external {
         vm.expectEmit(true, true, true, true);
-        emit ConfigUpdate(0, IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(_version));
+        emit ConfigUpdate(protocolVersions.VERSION(), IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(_version));
 
         vm.prank(protocolVersions.owner());
         protocolVersions.setRequired(ProtocolVersion.wrap(_version));
         assertEq(ProtocolVersion.unwrap(protocolVersions.required()), _version);
     }
+
+    /// @notice Tests owner-only access control via fuzzing different callers.
+    function testFuzz_setRequired_onlyOwner_reverts(address _notOwner, uint256 _ver) external {
+        vm.assume(_notOwner != protocolVersions.owner());
+        vm.prank(_notOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        protocolVersions.setRequired(ProtocolVersion.wrap(_ver));
+    }
+
 
     /// @notice Tests that `setRequired` reverts if the caller is not the owner.
     function test_setRequired_notOwner_reverts() external {
@@ -98,16 +117,25 @@ contract ProtocolVersions_SetRecommended_Test is ProtocolVersions_TestInit {
     /// @notice Tests that `setRecommended` updates the recommended protocol version successfully.
     function testFuzz_setRecommended_succeeds(uint256 _version) external {
         vm.expectEmit(true, true, true, true);
-        emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(_version));
+        emit ConfigUpdate(protocolVersions.VERSION(), IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(_version));
 
         vm.prank(protocolVersions.owner());
         protocolVersions.setRecommended(ProtocolVersion.wrap(_version));
         assertEq(ProtocolVersion.unwrap(protocolVersions.recommended()), _version);
     }
 
+    /// @notice Tests owner-only access control via fuzzing different callers.
+    function testFuzz_setRecommended_onlyOwner_reverts(address _notOwner, uint256 _ver) external {
+        vm.assume(_notOwner != protocolVersions.owner());
+        vm.prank(_notOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        protocolVersions.setRecommended(ProtocolVersion.wrap(_ver));
+    }
+
     /// @notice Tests that `setRecommended` reverts if the caller is not the owner.
     function test_setRecommended_notOwner_reverts() external {
         vm.expectRevert("Ownable: caller is not the owner");
+        
         protocolVersions.setRecommended(ProtocolVersion.wrap(0));
     }
 }


### PR DESCRIPTION
Summary
This PR enhances the ProtocolVersions.t.sol test suite to improve coverage, structure, and quality while preserving existing behavior.

Key changes
- Add ProtocolVersions_Version_Test to cover version() with a meaningful non-empty assertion
- Convert emitted ConfigUpdate events to use VERSION() constant for correctness and resilience
- Add two fuzz tests for owner-only access control on setRequired and setRecommended
- Keep all existing tests intact; only enhancements and reorganization where applicable

Details
- Tests now assert that the semantic version string is non-empty instead of relying on specific values
- ConfigUpdate(version, ...) now uses protocolVersions.VERSION() rather than a hard-coded 0, reflecting source contract semantics
- Added fuzz tests that confirm non-owners cannot call setRequired/setRecommended across varied addresses

Validation
- Ran: FOUNDRY_PROFILE=lite forge test --match-path test/L1/ProtocolVersions.t.sol -vv
- Heavy fuzz (ciheavy) for the new fuzz tests to ensure robustness
  * testFuzz_setRequired_onlyOwner_reverts(address,uint256)
  * testFuzz_setRecommended_onlyOwner_reverts(address,uint256)
- All tests pass locally with no semgrep violations and no compiler warnings

Notes
- No existing tests were removed; naming conforms to the documented test conventions

Co-authored-by: openhands <openhands@all-hands.dev>

@aliersh can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b6038ce4bd3b4951a92a51b9d6103aae)