### PR TITLE
refactor(test): improve ProtocolVersions test coverage and quality

### DIFF
--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -24,6 +24,15 @@ contract ProtocolVersions_TestInit is CommonTest {
     }
 }
 
+/// @title ProtocolVersions_Version_Test
+/// @notice Test contract for ProtocolVersions `version` function.
+contract ProtocolVersions_Version_Test is ProtocolVersions_TestInit {
+    /// @notice Tests that version returns a non-empty string.
+    function test_version_succeeds() external view {
+        assert(bytes(protocolVersions.version()).length > 0);
+    }
+}
+
 /// @title ProtocolVersions_Initialize_Test
 /// @notice Test contract for ProtocolVersions `initialize` function.
 contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
@@ -77,6 +86,7 @@ contract ProtocolVersions_Initialize_Test is ProtocolVersions_TestInit {
 contract ProtocolVersions_SetRequired_Test is ProtocolVersions_TestInit {
     /// @notice Tests that `setRequired` updates the required protocol version successfully.
     function testFuzz_setRequired_succeeds(uint256 _version) external {
+        _version = bound(_version, 0, type(uint128).max);
         vm.expectEmit(true, true, true, true);
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.REQUIRED_PROTOCOL_VERSION, abi.encode(_version));
 
@@ -97,6 +107,7 @@ contract ProtocolVersions_SetRequired_Test is ProtocolVersions_TestInit {
 contract ProtocolVersions_SetRecommended_Test is ProtocolVersions_TestInit {
     /// @notice Tests that `setRecommended` updates the recommended protocol version successfully.
     function testFuzz_setRecommended_succeeds(uint256 _version) external {
+        _version = bound(_version, 0, type(uint128).max);
         vm.expectEmit(true, true, true, true);
         emit ConfigUpdate(0, IProtocolVersions.UpdateType.RECOMMENDED_PROTOCOL_VERSION, abi.encode(_version));
 


### PR DESCRIPTION
# refactor(test): improve ProtocolVersions test coverage and quality

## Summary
Enhanced the ProtocolVersions test suite following established testing guidelines:

- **Added bounds to fuzz tests**: Applied `bound(_version, 0, type(uint128).max)` to `testFuzz_setRequired_succeeds` and `testFuzz_setRecommended_succeeds` for more realistic testing ranges
- **Added missing test coverage**: Created `ProtocolVersions_Version_Test` contract to test the `version()` function that was previously untested
- **Reorganized test structure**: Reordered test contracts to match the source contract's function declaration order (Version → Initialize → SetRequired → SetRecommended)

All tests pass including heavy fuzz testing with 20,000 runs each.

## Review & Testing Checklist for Human
- [ ] **Verify bound appropriateness**: Confirm `type(uint128).max` upper bound aligns with actual protocol version values used in deploy configs (e.g., mainnet uses `0x0000000000000000000000000000000000000003000000010000000000000000`)
- [ ] **Run full test suite**: Execute `just test-dev --match-path test/L1/ProtocolVersions.t.sol -v` to ensure no regressions
- [ ] **Validate version test**: Confirm the new version test provides sufficient coverage for the `version()` getter function

### Notes
- Bounds were chosen based on analysis of deploy config values across mainnet, sepolia, and hardhat environments
- Test reorganization maintains all existing functionality while improving maintainability
- Session requested by @aliersh
- Link to Devin run: https://app.devin.ai/sessions/dc0bd85f35f3496088d465732376a42f